### PR TITLE
Pr 581 ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dev = [
   "pytest>=9.0.3,<9.1.0",
   "pytest-cov>=4.0.0,<5.0.0",
   "radon>=6.0.0,<7.0.0",
-  "ruff>=0.1.0,<0.2.0",
+  "ruff>=0.15.12,<0.16.0",
   "toml>=0.10.2,<0.11.0",
   "tox>=4.0.8,<5.0.0",
   "tox-uv>=1.0.0,<2.0.0",
@@ -116,7 +116,7 @@ maintainers = [{name = "Christopher Pickering", email = "cpickering@rhc.net"}]
 name = "atlas-hub"
 readme = "readme.md"
 requires-python = ">=3.10,<4.0"
-version = "2.12.13"
+version = "2.12.14"
 
 [project.urls]
 Documentation = "https://www.atlas.bi/docs/hub/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -205,11 +205,15 @@ testpaths = "tests"
 
 [tool.ruff]
 extend-exclude = ['test*', 'ldap_auth*']
+
+[tool.ruff.lint]
 ignore = ['RUF015', 'B034', 'PLR1714', 'S602', 'S605', 'D213', 'S324', 'D203', 'S301', 'N818', 'PLW0120', 'PLR0915', 'S110', 'S101', 'C417', 'PLR0913', 'D212', 'RUF100', 'B020', 'S106', 'PLC1901', 'PLR0911', 'F401', "E501", 'SIM118', 'PLR2004', 'PLW2901', 'B905', 'E402', 'PLR0912', 'B904', 'ERA001', 'PLR5501', 'D401', 'SIM108']
 select = ['F', 'E', 'W', 'N', 'D', 'S', 'B', 'C4', 'T20', 'Q', 'SIM', 'ERA', 'PL', 'RUF']
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "runner/scripts/em_python.py" = ['SIM114']
+"runner/scripts/em_cmd.py" = ['S603']
+"runner/scripts/em_ssh.py" = ['S507']
 
 [tool.setuptools_scm]
 local_scheme = "dirty-tag"

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -35,6 +35,7 @@ Database model should be cloned from `web` before running app.
 
 """
 
+from importlib import import_module
 import logging
 import os
 
@@ -45,53 +46,37 @@ from runner.extensions import db, executor, redis_client
 logging.basicConfig(level=logging.WARNING)
 
 
+def _load_config(env: str) -> object:
+    config_name = {
+        "development": "DevConfig",
+        "demo": "DemoConfig",
+        "test": "TestConfig",
+    }.get(env, "Config")
+
+    for module_name in ("config_cust", "config"):
+        try:
+            module = import_module(module_name)
+            return getattr(module, config_name)()
+        except (AttributeError, ImportError):
+            continue
+
+    raise ImportError(f"Unable to load configuration for env {env!r}.")
+
+
+def _register_blueprints(app: Flask) -> None:
+    filters_module = import_module("runner.web.filters")
+    web_module = import_module("runner.web.web")
+
+    app.register_blueprint(web_module.web_bp)
+    app.register_blueprint(filters_module.filters_bp)
+
+
 def create_app() -> Flask:
     """Create task runner app."""
     # pylint: disable=W0621
     app = Flask(__name__)
     app.config["ENV"] = os.environ.get("FLASK_ENV", "production")
-
-    if app.config["ENV"] == "development":
-        try:
-            from config_cust import DevConfig as DevConfigCust
-
-            app.config.from_object(DevConfigCust())
-        except ImportError:
-            from config import DevConfig
-
-            app.config.from_object(DevConfig())
-
-    elif app.config["ENV"] == "demo":
-        try:
-            from config_cust import DemoConfig as DemoConfigCust
-
-            app.config.from_object(DemoConfigCust())
-        except ImportError:
-            from config import DemoConfig
-
-            app.config.from_object(DemoConfig())
-
-    elif app.config["ENV"] == "test":
-        try:
-            from config_cust import (
-                TestConfig as TestConfigCust,  # type: ignore[attr-defined]
-            )
-
-            app.config.from_object(TestConfigCust())
-        except ImportError:
-            from config import TestConfig
-
-            app.config.from_object(TestConfig())
-
-    else:
-        try:
-            from config_cust import Config as ConfigCust
-
-            app.config.from_object(ConfigCust())
-        except ImportError:
-            from config import Config
-
-            app.config.from_object(Config())
+    app.config.from_object(_load_config(app.config["ENV"]))
 
     db.init_app(app)
 
@@ -100,12 +85,7 @@ def create_app() -> Flask:
     redis_client.init_app(app)
 
     with app.app_context():
-        # pylint: disable=C0415
-
-        from runner.web import filters, web
-
-        app.register_blueprint(web.web_bp)
-        app.register_blueprint(filters.filters_bp)
+        _register_blueprints(app)
 
         return app
 

--- a/runner/__init__.py
+++ b/runner/__init__.py
@@ -35,9 +35,9 @@ Database model should be cloned from `web` before running app.
 
 """
 
-from importlib import import_module
 import logging
 import os
+from importlib import import_module
 
 from flask import Flask
 

--- a/runner/scripts/em_ftp.py
+++ b/runner/scripts/em_ftp.py
@@ -133,7 +133,7 @@ class Ftp:
             else:
                 data_file.write(data)
 
-            original_name = str(self.dir.joinpath(file_name.split("/")[-1]))
+            original_name = str(self.dir.joinpath(file_name.rsplit("/", 1)[-1]))
             if os.path.islink(original_name):
                 os.unlink(original_name)
             elif os.path.isfile(original_name):
@@ -163,7 +163,7 @@ class Ftp:
                 RunnerLog(self.task, self.run_id, 13, "Searching for matching files...")
 
                 # get the path up to the *
-                base_dir = str(Path(file_name.split("*")[0]).parent)
+                base_dir = str(Path(file_name.split("*", 1)[0]).parent)
 
                 file_list = []
                 for _, _, walk_file_list in self._walk(base_dir):

--- a/runner/scripts/em_sftp.py
+++ b/runner/scripts/em_sftp.py
@@ -203,7 +203,7 @@ class Sftp:
                 else:
                     data_file.write(data)
 
-            original_name = str(self.dir.joinpath(file_name.split("/")[-1]))
+            original_name = str(self.dir.joinpath(file_name.rsplit("/", 1)[-1]))
             if os.path.islink(original_name):
                 os.unlink(original_name)
             elif os.path.isfile(original_name):
@@ -241,7 +241,7 @@ class Sftp:
                 RunnerLog(self.task, self.run_id, 9, "Searching for matching files...")
 
                 # get the path up to the *
-                base_dir = str(Path(file_name.split("*")[0]).parent)
+                base_dir = str(Path(file_name.split("*", 1)[0]).parent)
 
                 file_list = []
                 for _, _, walk_file_list in self._walk(base_dir):

--- a/runner/scripts/em_smb.py
+++ b/runner/scripts/em_smb.py
@@ -221,7 +221,7 @@ class Smb:
                 else:
                     data_file.write(data)
 
-            original_name = str(self.dir.joinpath(file_name.split("/")[-1]))
+            original_name = str(self.dir.joinpath(file_name.rsplit("/", 1)[-1]))
             if os.path.islink(original_name):
                 os.unlink(original_name)
             elif os.path.isfile(original_name):
@@ -251,7 +251,7 @@ class Smb:
                 # through the folders that match.
 
                 # get the path up to the *.
-                base_dir = str(Path(file_name.split("*")[0]).parent)
+                base_dir = str(Path(file_name.split("*", 1)[0]).parent)
 
                 file_list = []
                 for _, _, walk_file_list in self._walk(base_dir):

--- a/scheduler/__init__.py
+++ b/scheduler/__init__.py
@@ -42,9 +42,9 @@ Database model should be cloned from `web` before running app.
 """
 
 import contextlib
-from importlib import import_module
 import logging
 import os
+from importlib import import_module
 
 from apscheduler.schedulers import SchedulerAlreadyRunningError
 from flask import Flask, jsonify, make_response

--- a/scheduler/__init__.py
+++ b/scheduler/__init__.py
@@ -42,6 +42,7 @@ Database model should be cloned from `web` before running app.
 """
 
 import contextlib
+from importlib import import_module
 import logging
 import os
 
@@ -52,59 +53,67 @@ from werkzeug import Response
 from scheduler.extensions import atlas_scheduler, db
 
 
+def _load_config(env: str) -> object:
+    config_name = {
+        "development": "DevConfig",
+        "demo": "DemoConfig",
+        "test": "TestConfig",
+    }.get(env, "Config")
+
+    for module_name in ("config_cust", "config"):
+        try:
+            module = import_module(module_name)
+            return getattr(module, config_name)()
+        except (AttributeError, ImportError):
+            continue
+
+    raise ImportError(f"Unable to load configuration for env {env!r}.")
+
+
+def _register_scheduler_components(app: Flask) -> None:
+    apscheduler_events = import_module("apscheduler.events")
+    web_module = import_module("scheduler.web")
+    scheduler_events = import_module("scheduler.events")
+
+    app.register_blueprint(web_module.web_bp)
+
+    atlas_scheduler.add_listener(
+        scheduler_events.job_missed,
+        apscheduler_events.EVENT_JOB_MISSED,
+    )
+    atlas_scheduler.add_listener(
+        scheduler_events.job_error,
+        apscheduler_events.EVENT_JOB_ERROR,
+    )
+    atlas_scheduler.add_listener(
+        scheduler_events.job_executed,
+        apscheduler_events.EVENT_JOB_EXECUTED,
+    )
+    atlas_scheduler.add_listener(
+        scheduler_events.job_added,
+        apscheduler_events.EVENT_JOB_ADDED,
+    )
+    atlas_scheduler.add_listener(
+        scheduler_events.job_removed,
+        apscheduler_events.EVENT_JOB_REMOVED,
+    )
+    atlas_scheduler.add_listener(
+        scheduler_events.job_submitted,
+        apscheduler_events.EVENT_JOB_SUBMITTED,
+    )
+
+
 def create_app() -> Flask:
     """Create task runner app."""
     # pylint: disable=W0621
     app = Flask(__name__)
 
     app.config["ENV"] = os.environ.get("FLASK_ENV", "production")
-
-    if app.config["ENV"] == "development":
-        try:
-            from config_cust import DevConfig as DevConfigCust
-
-            app.config.from_object(DevConfigCust())
-        except ImportError:
-            from config import DevConfig
-
-            app.config.from_object(DevConfig())
-
-    elif app.config["ENV"] == "demo":
-        try:
-            from config_cust import DemoConfig as DemoConfigCust
-
-            app.config.from_object(DemoConfigCust())
-        except ImportError:
-            from config import DemoConfig
-
-            app.config.from_object(DemoConfig())
-
-    elif app.config["ENV"] == "test":
-        try:
-            from config_cust import (
-                TestConfig as TestConfigCust,  # type: ignore[attr-defined]
-            )
-
-            app.config.from_object(TestConfigCust())
-        except ImportError:
-            from config import TestConfig
-
-            app.config.from_object(TestConfig())
-
-    else:
-        try:
-            from config_cust import Config as ConfigCust
-
-            app.config.from_object(ConfigCust())
-        except ImportError:
-            from config import Config
-
-            app.config.from_object(Config())
+    app.config.from_object(_load_config(app.config["ENV"]))
 
     db.init_app(app)
 
-    # pylint: disable=W0611
-    from scheduler import maintenance  # noqa: F401
+    import_module("scheduler.maintenance")
 
     with contextlib.suppress(SchedulerAlreadyRunningError):
         # pytest imports twice, this will catch on the second import.
@@ -119,39 +128,12 @@ def create_app() -> Flask:
             # second import.
             atlas_scheduler.start()
 
-        # pylint: disable=C0415
-        from apscheduler.events import (
-            EVENT_JOB_ADDED,
-            EVENT_JOB_ERROR,
-            EVENT_JOB_EXECUTED,
-            EVENT_JOB_MISSED,
-            EVENT_JOB_REMOVED,
-            EVENT_JOB_SUBMITTED,
-        )
-
-        from scheduler import web
-        from scheduler.events import (
-            job_added,
-            job_error,
-            job_executed,
-            job_missed,
-            job_removed,
-            job_submitted,
-        )
-
-        app.register_blueprint(web.web_bp)
+        _register_scheduler_components(app)
 
         if app.config["ENV"] == "test":
             logging.getLogger("apscheduler").setLevel(logging.INFO)
         else:
             logging.getLogger("apscheduler").setLevel(logging.ERROR)
-
-        atlas_scheduler.add_listener(job_missed, EVENT_JOB_MISSED)
-        atlas_scheduler.add_listener(job_error, EVENT_JOB_ERROR)
-        atlas_scheduler.add_listener(job_executed, EVENT_JOB_EXECUTED)
-        atlas_scheduler.add_listener(job_added, EVENT_JOB_ADDED)
-        atlas_scheduler.add_listener(job_removed, EVENT_JOB_REMOVED)
-        atlas_scheduler.add_listener(job_submitted, EVENT_JOB_SUBMITTED)
 
         @app.errorhandler(404)
         @app.errorhandler(500)

--- a/scheduler/web.py
+++ b/scheduler/web.py
@@ -55,8 +55,7 @@ def schedule() -> Response:
         if (
             job.id in ["job_sync", "job_clean_orphans", "temp_clean"]
             or not hasattr(job, "next_run_time")
-            or job.next_run_time is None
-            and job.args
+            or (job.next_run_time is None and job.args)
         ):
             continue
 

--- a/tox.ini
+++ b/tox.ini
@@ -54,7 +54,7 @@ description = check code style
 commands =
     isort . --check
     black . --fast --check
-    ruff scheduler/ web/ runner/
+    ruff check scheduler/ web/ runner/
     mypy scheduler web runner --show-traceback --show-error-codes
     djlint . -e html.j2 --check --quiet
     djlint . -e html.j2 --lint

--- a/uv.lock
+++ b/uv.lock
@@ -44,7 +44,7 @@ wheels = [
 
 [[package]]
 name = "atlas-hub"
-version = "2.12.13"
+version = "2.12.14"
 source = { editable = "." }
 dependencies = [
     { name = "azure-devops" },
@@ -195,7 +195,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3,<9.1.0" },
     { name = "pytest-cov", specifier = ">=4.0.0,<5.0.0" },
     { name = "radon", specifier = ">=6.0.0,<7.0.0" },
-    { name = "ruff", specifier = ">=0.1.0,<0.2.0" },
+    { name = "ruff", specifier = ">=0.15.12,<0.16.0" },
     { name = "toml", specifier = ">=0.10.2,<0.11.0" },
     { name = "tox", specifier = ">=4.0.8,<5.0.0" },
     { name = "tox-uv", specifier = ">=1.0.0,<2.0.0" },
@@ -2601,26 +2601,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.1.15"
+version = "0.15.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/42/33/7165f88a156be1c2fd13a18b3af6e75bbf82da5b6978cd2128d666accc18/ruff-0.1.15.tar.gz", hash = "sha256:f6dfa8c1b21c913c326919056c390966648b680966febcb796cc9d1aaab8564e", size = 1971643, upload-time = "2024-01-29T23:06:05.541Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/2c/fac0658910ea3ea87a23583e58277533154261b73f9460388eb2e6e02e8f/ruff-0.1.15-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5fe8d54df166ecc24106db7dd6a68d44852d14eb0729ea4672bb4d96c320b7df", size = 14357437, upload-time = "2024-01-29T23:05:04.991Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/c1/2116927385c761ffb786dfb77654a634ecd7803dee4de3b47b59536374f1/ruff-0.1.15-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6f0bfbb53c4b4de117ac4d6ddfd33aa5fc31beeaa21d23c45c6dd249faf9126f", size = 7329669, upload-time = "2024-01-29T23:05:12.437Z" },
-    { url = "https://files.pythonhosted.org/packages/18/d7/2199ecb42cef4d70de0e72ce4ca8878d060e25fe4434cb66f51e26158a2a/ruff-0.1.15-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e0d432aec35bfc0d800d4f70eba26e23a352386be3a6cf157083d18f6f5881c8", size = 7137343, upload-time = "2024-01-29T23:05:16.159Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/e0/8a6f9db2c5b8c7108c7e7347cd6beca805d1b2ae618569c72f2515d11e52/ruff-0.1.15-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9405fa9ac0e97f35aaddf185a1be194a589424b8713e3b97b762336ec79ff807", size = 6563223, upload-time = "2024-01-29T23:05:19.687Z" },
-    { url = "https://files.pythonhosted.org/packages/98/fa/2a627747a5a5f7e1d3447704f795fd35d486460838485762cd569ef8eb0e/ruff-0.1.15-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c66ec24fe36841636e814b8f90f572a8c0cb0e54d8b5c2d0e300d28a0d7bffec", size = 7534853, upload-time = "2024-01-29T23:05:23.18Z" },
-    { url = "https://files.pythonhosted.org/packages/55/09/c09d0f9b41d1f5e3de117579f2fcdb7063fd76cd92d6614eae1b77ccbccb/ruff-0.1.15-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:6f8ad828f01e8dd32cc58bc28375150171d198491fc901f6f98d2a39ba8e3ff5", size = 8168826, upload-time = "2024-01-29T23:05:26.544Z" },
-    { url = "https://files.pythonhosted.org/packages/72/48/c9dfc2c87dc6b92446d8092c2be25b42ca4fb201cecb2499996ccf483c34/ruff-0.1.15-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:86811954eec63e9ea162af0ffa9f8d09088bab51b7438e8b6488b9401863c25e", size = 7942963, upload-time = "2024-01-29T23:05:30.655Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/57/dbc885f94450335fcff82301c4b25cf614894e79d9afbd249714e709ab42/ruff-0.1.15-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fd4025ac5e87d9b80e1f300207eb2fd099ff8200fa2320d7dc066a3f4622dc6b", size = 8524998, upload-time = "2024-01-29T23:05:34.503Z" },
-    { url = "https://files.pythonhosted.org/packages/39/75/8dea2fc156ae525971fdada8723f78e605dcf89428f5686728438b12f9ef/ruff-0.1.15-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b17b93c02cdb6aeb696effecea1095ac93f3884a49a554a9afa76bb125c114c1", size = 7534144, upload-time = "2024-01-29T23:05:38.642Z" },
-    { url = "https://files.pythonhosted.org/packages/47/41/96b770475c46590bfd051ca0c5f797b2d45f2638c45f3a9daf1ae55b96d6/ruff-0.1.15-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:ddb87643be40f034e97e97f5bc2ef7ce39de20e34608f3f829db727a93fb82c5", size = 7055002, upload-time = "2024-01-29T23:05:41.955Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/ca/4066dbcc3631a4efe1fe695f42f20aca50474d760b3bd8e57d7565d75aa5/ruff-0.1.15-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:abf4822129ed3a5ce54383d5f0e964e7fef74a41e48eb1dfad404151efc130a2", size = 6552130, upload-time = "2024-01-29T23:05:45.487Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/85/da93f0fc8f2424cf776fcce6daef9291162345179d16faf1401ff2890068/ruff-0.1.15-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6c629cf64bacfd136c07c78ac10a54578ec9d1bd2a9d395efbee0935868bf852", size = 7214386, upload-time = "2024-01-29T23:05:48.346Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/bf/de34ad339e0d1f6faa858cbcf793f3abc168b7aa516dd9227d843b992be8/ruff-0.1.15-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1bab866aafb53da39c2cadfb8e1c4550ac5340bb40300083eb8967ba25481447", size = 7602787, upload-time = "2024-01-29T23:05:51.341Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/61/ffdccecb0b39521d7060d6a6bc33c53d7f20d48d3511d6333cb01f26e979/ruff-0.1.15-py3-none-win32.whl", hash = "sha256:2417e1cb6e2068389b07e6fa74c306b2810fe3ee3476d5b8a96616633f40d14f", size = 6670488, upload-time = "2024-01-29T23:05:54.454Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/5f/3ba51cc770ed2b2df88efc32bba26759e6ac5c6149319a60913a85230936/ruff-0.1.15-py3-none-win_amd64.whl", hash = "sha256:3837ac73d869efc4182d9036b1405ef4c73d9b1f88da2413875e34e0d6919587", size = 7319395, upload-time = "2024-01-29T23:05:58.135Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/bd/c196493563d6bf8fe960f10b83926a3fae3a43a96eac6b263aecb96c61d7/ruff-0.1.15-py3-none-win_arm64.whl", hash = "sha256:9a933dfb1c14ec7a33cceb1e49ec4a16b51ce3c20fd42663198746efc0427360", size = 6998592, upload-time = "2024-01-29T23:06:01.904Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,7 +1,11 @@
 """Web Startup."""
 
+from importlib import import_module
+import os
 import sys
 from pathlib import Path
+
+from flask import Flask, render_template  # isort:skip
 
 from web.extensions import (
     cache,
@@ -17,12 +21,61 @@ from web.extensions import (
     web_assets,
 )
 
-from flask import Flask, render_template  # isort:skip
-
 sys.path.append(str(Path(__file__).parents[1]) + "/scripts")
 sys.path.append(str(Path(__file__).parents[2]))
 from error_print import full_stack  # isort:skip
-import os
+
+
+def _load_config(env: str) -> object:
+    config_name = {
+        "development": "DevConfig",
+        "demo": "DemoConfig",
+        "test": "TestConfig",
+    }.get(env, "Config")
+
+    for module_name in ("config_cust", "config"):
+        try:
+            module = import_module(module_name)
+            return getattr(module, config_name)()
+        except (AttributeError, ImportError):
+            continue
+
+    raise ImportError(f"Unable to load configuration for env {env!r}.")
+
+
+def _register_blueprints(app: Flask) -> object:
+    cli_module = import_module("web.cli")
+    assets_module = import_module("web.web.assets")
+    admin_module = import_module("web.web.admin")
+    auth_module = import_module("web.web.auth")
+    connection_module = import_module("web.web.connection")
+    dashboard_module = import_module("web.web.dashboard")
+    executors_module = import_module("web.web.executors")
+    filters_module = import_module("web.web.filters")
+    project_module = import_module("web.web.project")
+    saml_auth_module = import_module("web.web.saml_auth")
+    table_module = import_module("web.web.table")
+    task_module = import_module("web.web.task")
+    task_controls_module = import_module("web.web.task_controls")
+    task_edit_module = import_module("web.web.task_edit")
+    task_files_module = import_module("web.web.task_files")
+
+    app.register_blueprint(saml_auth_module.login_bp)
+    app.register_blueprint(admin_module.admin_bp)
+    app.register_blueprint(auth_module.auth_bp)
+    app.register_blueprint(connection_module.connection_bp)
+    app.register_blueprint(project_module.project_bp)
+    app.register_blueprint(task_module.task_bp)
+    app.register_blueprint(task_controls_module.task_controls_bp)
+    app.register_blueprint(task_edit_module.task_edit_bp)
+    app.register_blueprint(task_files_module.task_files_bp)
+    app.register_blueprint(dashboard_module.dashboard_bp)
+    app.register_blueprint(table_module.table_bp)
+    app.register_blueprint(executors_module.executors_bp)
+    app.register_blueprint(filters_module.filters_bp)
+    app.register_blueprint(cli_module.cli_bp)
+
+    return assets_module
 
 
 def create_app() -> Flask:
@@ -31,52 +84,15 @@ def create_app() -> Flask:
     app = Flask(__name__)
 
     app.config["ENV"] = os.environ.get("FLASK_ENV", "production")
+    app.config.from_object(_load_config(app.config["ENV"]))
 
-    if app.config["ENV"] == "development":
-        try:
-            from config_cust import DevConfig as DevConfigCust
-
-            app.config.from_object(DevConfigCust())
-        except ImportError:
-            from config import DevConfig
-
-            app.config.from_object(DevConfig())
-
-    elif app.config["ENV"] == "demo":
-        try:
-            from config_cust import DemoConfig as DemoConfigCust
-
-            app.config.from_object(DemoConfigCust())
-        except ImportError:
-            from config import DemoConfig
-
-            app.config.from_object(DemoConfig())
-
-        from whitenoise import WhiteNoise
-
-        app.wsgi_app = WhiteNoise(app.wsgi_app, root="web/static/", prefix="static/")  # type: ignore[assignment]
-
-    elif app.config["ENV"] == "test":
-        try:
-            from config_cust import (
-                TestConfig as TestConfigCust,  # type: ignore[attr-defined]
-            )
-
-            app.config.from_object(TestConfigCust())
-        except ImportError:
-            from config import TestConfig
-
-            app.config.from_object(TestConfig())
-
-    else:
-        try:
-            from config_cust import Config as ConfigCust
-
-            app.config.from_object(ConfigCust())
-        except ImportError:
-            from config import Config
-
-            app.config.from_object(Config())
+    if app.config["ENV"] == "demo":
+        white_noise = import_module("whitenoise")
+        app.wsgi_app = white_noise.WhiteNoise(  # type: ignore[assignment]
+            app.wsgi_app,
+            root="web/static/",
+            prefix="static/",
+        )
 
     web_assets.init_app(app)
     compress.init_app(app)
@@ -107,44 +123,11 @@ def create_app() -> Flask:
     htmlmin.init_app(app)
 
     with app.app_context():
-        # pylint: disable=W0611
-        from web import cli
-        from web.web import assets  # noqa: F401
-        from web.web import (
-            admin,
-            auth,
-            connection,
-            dashboard,
-            executors,
-            filters,
-            project,
-            saml_auth,
-            table,
-            task,
-            task_controls,
-            task_edit,
-            task_files,
-        )
-
-        app.register_blueprint(saml_auth.login_bp)
-        app.register_blueprint(admin.admin_bp)
-        app.register_blueprint(auth.auth_bp)
-        app.register_blueprint(connection.connection_bp)
-        app.register_blueprint(project.project_bp)
-        app.register_blueprint(task.task_bp)
-        app.register_blueprint(task_controls.task_controls_bp)
-        app.register_blueprint(task_edit.task_edit_bp)
-        app.register_blueprint(task_files.task_files_bp)
-        app.register_blueprint(dashboard.dashboard_bp)
-        app.register_blueprint(table.table_bp)
-        app.register_blueprint(executors.executors_bp)
-        app.register_blueprint(filters.filters_bp)
-        app.register_blueprint(cli.cli_bp)
+        assets = _register_blueprints(app)
 
         if app.config["DEBUG"]:
-            from flask_debugtoolbar import DebugToolbarExtension
-
-            toolbar = DebugToolbarExtension()
+            toolbar_module = import_module("flask_debugtoolbar")
+            toolbar = toolbar_module.DebugToolbarExtension()
             toolbar.init_app(app)
             assets.cache = False  # type: ignore[attr-defined]
             assets.manifest = False  # type: ignore[attr-defined]

--- a/web/__init__.py
+++ b/web/__init__.py
@@ -1,11 +1,9 @@
 """Web Startup."""
 
-from importlib import import_module
 import os
 import sys
+from importlib import import_module
 from pathlib import Path
-
-from flask import Flask, render_template  # isort:skip
 
 from web.extensions import (
     cache,
@@ -20,6 +18,8 @@ from web.extensions import (
     sess,
     web_assets,
 )
+
+from flask import Flask, render_template  # isort:skip
 
 sys.path.append(str(Path(__file__).parents[1]) + "/scripts")
 sys.path.append(str(Path(__file__).parents[2]))

--- a/web/cli.py
+++ b/web/cli.py
@@ -1,7 +1,7 @@
 """EM Web Custom CLI."""
 
-from importlib import import_module
 import sys
+from importlib import import_module
 from pathlib import Path
 
 from flask import Blueprint

--- a/web/cli.py
+++ b/web/cli.py
@@ -1,5 +1,6 @@
 """EM Web Custom CLI."""
 
+from importlib import import_module
 import sys
 from pathlib import Path
 
@@ -19,31 +20,6 @@ cli_bp = Blueprint("cli", __name__)
 def create_db() -> None:
     """Add command to create the test database."""
     if app.config["ENV"] in ["test", "development"]:
-        # pylint: disable=W0611
-        from web.model import (  # noqa: F401
-            Connection,
-            ConnectionDatabase,
-            ConnectionDatabaseType,
-            ConnectionFtp,
-            ConnectionGpg,
-            ConnectionSftp,
-            ConnectionSmb,
-            ConnectionSsh,
-            Login,
-            LoginType,
-            Project,
-            QuoteLevel,
-            Task,
-            TaskDestinationFileType,
-            TaskFile,
-            TaskLog,
-            TaskProcessingType,
-            TaskSourceQueryType,
-            TaskSourceType,
-            TaskStatus,
-            User,
-        )
-
         db.drop_all()
         db.session.commit()
 
@@ -70,15 +46,15 @@ def db_seed() -> None:
     poetry run flask --app=web cli seed
     """
     sys.path.append(str(Path(__file__).parents[1]) + "/scripts")
-    from database import seed
+    database_module = import_module("database")
 
-    seed(db.session, model)
+    database_module.seed(db.session, model)
 
 
 @cli_bp.cli.command("seed_demo")
 @with_appcontext
 def db_seed_demo() -> None:
     """Add command to seed the database for a demo."""
-    from .seed import seed_demo
+    seed_demo = import_module("web.seed").seed_demo
 
     seed_demo()

--- a/web/web/auth.py
+++ b/web/web/auth.py
@@ -151,7 +151,7 @@ def login() -> Union[str, Response]:
         saml = SAML(app)
         saml_client = saml.saml_client_for()
         # pylint: disable=W0612
-        reqid, info = saml_client.prepare_for_authenticate()
+        _reqid, info = saml_client.prepare_for_authenticate()
 
         redirect_url = ""
         # Select the IdP URL to send the AuthN request to

--- a/web/web/filters.py
+++ b/web/web/filters.py
@@ -202,7 +202,7 @@ def database_pass(my_string: str) -> str:
         elif "password" in my_string:
             my_pass = my_string.split("password=")[1]
         else:
-            my_pass = my_string.split("@")[0].split(":")[1]
+            my_pass = my_string.split("@", 1)[0].split(":", 1)[1]
 
         return my_string.replace(
             my_pass,

--- a/web/web/table.py
+++ b/web/web/table.py
@@ -826,7 +826,7 @@ def project_all_tasks(project_id: int) -> Response:
                     if task["Next Run"] and isinstance(task["Next Run"], datetime.datetime)
                     else (task["Next Run"] if task["Next Run"] else "")
                 ),
-                "Run Rank": (task["Run Rank"] if "Run Rank" in task else None),
+                "Run Rank": task.get("Run Rank"),
             }
         )
 


### PR DESCRIPTION
Updates PR #581 to pass ruff 0.15.12 by fixing new lint violations in app bootstrap modules and helper scripts, moving Ruff settings to [tool.ruff.lint], and keeping
  only two narrowly scoped per-file ignores for the behavior-sensitive security rules in runner/scripts/em_cmd.py and runner/scripts/em_ssh.py.